### PR TITLE
Follow API updates in Flutter 3.10

### DIFF
--- a/lib/src/selectable_text.dart
+++ b/lib/src/selectable_text.dart
@@ -67,7 +67,7 @@ class _SelectableTextSelectionGestureDetectorBuilder
   var _cancelSingleLongTapEnd = false;
 
   @override
-  void onTapDown(TapDownDetails details) {
+  void onTapDown(TapDragDownDetails details) {
     final position = renderEditable.getPositionForPoint(details.globalPosition);
     final span = renderEditable.text!.getSpanForPosition(position);
     if (span is HighlightedTextSpan) {
@@ -91,7 +91,7 @@ class _SelectableTextSelectionGestureDetectorBuilder
   }
 
   @override
-  void onSingleTapUp(TapUpDetails details) {
+  void onSingleTapUp(TapDragUpDetails details) {
     try {
       _cancelDoubleTapDown = false;
       editableText.hideToolbar();
@@ -186,7 +186,7 @@ class _SelectableTextSelectionGestureDetectorBuilder
   }
 
   @override
-  void onDoubleTapDown(TapDownDetails details) {
+  void onDoubleTapDown(TapDragDownDetails details) {
     _clearHighlight();
     if (!_cancelDoubleTapDown) {
       super.onDoubleTapDown(details);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,8 @@ version: 2.5.0
 homepage: https://github.com/miyakeryo/flutter_selectable_autolink_text
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  flutter: ">=3.10.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
From Flutter 3.10, argument classes of `TextSelectionGestureDetectorBuilder` are changed(https://github.com/flutter/flutter/commit/9080d1acc58f3d45ae3f4a94c9ab231236aa843d).

This PR follows the updates, and updates SDK constraints to ensure that new version of this package is used in Flutter 3.10 or later.